### PR TITLE
If no theme value has been set in local settings, set the theme value to current RequestTheme at startup

### DIFF
--- a/BreadPlayer.Core/App.xaml.cs
+++ b/BreadPlayer.Core/App.xaml.cs
@@ -54,16 +54,25 @@ namespace BreadPlayer
         {
             this.InitializeComponent();
             CoreApplication.EnablePrelaunch(true);
+            InitializeTheme();
+            this.Suspending += OnSuspending;
+            this.EnteredBackground += App_EnteredBackground;
+            this.LeavingBackground += App_LeavingBackground;   
+        }
+
+        private void InitializeTheme()
+        {
             var value = ApplicationData.Current.LocalSettings.Values["SelectedTheme"];
             if (value != null)
             {
                 var theme = Enum.Parse(typeof(ApplicationTheme), value.ToString());
-                this.RequestedTheme = (ApplicationTheme)theme;
-                Debug.Write("ApplicationTheme: " + RequestedTheme.ToString());
+                this.RequestedTheme = (ApplicationTheme) theme;
+                Debug.Write("ApplicationTheme: " + RequestedTheme);
             }
-            this.Suspending += OnSuspending;
-            this.EnteredBackground += App_EnteredBackground;
-            this.LeavingBackground += App_LeavingBackground;   
+            else
+            {
+                ApplicationData.Current.LocalSettings.Values["SelectedTheme"] = RequestedTheme.ToString();
+            }
         }
 
         private void App_LeavingBackground(object sender, LeavingBackgroundEventArgs e)


### PR DESCRIPTION
At first startup, there are no theme value in Application settings, so the app will load the system default theme, 
if the system default theme is dark,  go to *Settings* -> *Personalization*, the *Theme* is toggled to *Light*, this can be a little confusing.