### PR TITLE
Fix ArgumentOutOfRangeException

### DIFF
--- a/BreadPlayer.Views.UWP/Extensions/StringExtensions.cs
+++ b/BreadPlayer.Views.UWP/Extensions/StringExtensions.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace BreadPlayer.Extensions
 {
-	public static class StringExtensions
+    public static class StringExtensions
     {
         public static string ToSha1(this string text) => SHA1.Create().ComputeHash(text.ToBytes()).ToHex();
         public static byte[] ToBytes(this string text) => Encoding.UTF8.GetBytes(text);
@@ -13,19 +13,22 @@ namespace BreadPlayer.Extensions
 
         public static bool StartsWithLetter(this string input)
         {
-            return Regex.Match(input.Remove(1), "[a-zA-Z]").Success;
+            return !string.IsNullOrEmpty(input) && char.IsLetter(input[0]);
         }
+
         public static bool StartsWithNumber(this string input)
         {
-            return Regex.Match(input.Remove(1), "\\d").Success;
+            return !string.IsNullOrEmpty(input) && Regex.IsMatch(input, @"^\d+");
         }
+
         public static bool StartsWithSymbol(this string input)
         {
-            return Regex.Match(input.Remove(1), "[^a-zA-Z0-9]").Success;
+            return !string.IsNullOrEmpty(input) && Regex.IsMatch(input, "[^a-zA-Z0-9]");
         }
+
         public static bool ContainsOnlyNumbers(this string input)
         {
-            return Regex.Match(input, "\\d").Success;
+            return !string.IsNullOrEmpty(input) && Regex.IsMatch(input, "\\d");
         }
     }
 }

--- a/BreadPlayer.Views.UWP/ViewModels/LibraryViewModel.cs
+++ b/BreadPlayer.Views.UWP/ViewModels/LibraryViewModel.cs
@@ -25,6 +25,7 @@ using BreadPlayer.Service;
 using BreadPlayer.Services;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -663,23 +664,32 @@ namespace BreadPlayer.ViewModels
             switch (propName)
             {
                 case "Title":
-                    f = t => GetPropValue(t, propName).ToString().StartsWithLetter() ? (GetPropValue(t, propName) as string).Remove(1).ToUpper() : GetPropValue(t, propName).ToString().StartsWithNumber() ? "#" : GetPropValue(t, propName).ToString().StartsWithSymbol() ? "&" : (GetPropValue(t, propName) as string); //determine whether the Title, by which groups are made, start with number, letter or symbol. On the basis of that we define the Key for each Group.
+                    //determine whether the Title, by which groups are made, start with number, letter or symbol. On the basis of that we define the Key for each Group.
+                    f = t =>
+                    {
+                        if (t.Title.StartsWithLetter()) return t.Title[0].ToString().ToUpper();
+                        if (t.Title.StartsWithNumber()) return "#";
+                        if (t.Title.StartsWithSymbol()) return "&";
+                        return t.Title;
+                    };
                     break;
                 case "Year":
-                    f = t => string.IsNullOrEmpty(GetPropValue(t, propName) as String) ? "Unknown Year" : GetPropValue(t, propName) as string;
+                    f = t => string.IsNullOrEmpty(t.Year) ? "Unknown Year" : t.Year;
                     break;
                 case "Length":
                     string[] timeformats = { @"m\:ss", @"mm\:ss", @"h\:mm\:ss", @"hh\:mm\:ss" };
-                    f = t => string.IsNullOrEmpty(GetPropValue(t, propName) as String) || GetPropValue(t, propName) as String == "0:00" ? "Unknown Length" : Math.Round((TimeSpan.ParseExact((GetPropValue(t, propName) as String), timeformats, System.Globalization.CultureInfo.InvariantCulture).TotalMinutes)).ToString() + " minutes";
+                    f = t => string.IsNullOrEmpty(t.Length) || t.Length == "0:00" 
+                    ? "Unknown Length"
+                    : Math.Round(TimeSpan.ParseExact(t.Length, timeformats, CultureInfo.InvariantCulture).TotalMinutes) + " minutes";
                     break;
                 case "TrackNumber":
-                    f = t => string.IsNullOrEmpty(GetPropValue(t, propName) as String) ? "Unknown Track No." : (GetPropValue(t, propName) as String);
+                    f = t => string.IsNullOrEmpty(t.TrackNumber) ? "Unknown Track No." : t.TrackNumber;
                     break;
                 case "FolderPath":
-                    f = t => string.IsNullOrEmpty(GetPropValue(t, propName) as String) ? "Unknown Folder" : new DirectoryInfo((GetPropValue(t, propName) as String)).FullName;
+                    f = t => string.IsNullOrEmpty(t.FolderPath) ? "Unknown Folder" : new DirectoryInfo(t.FolderPath).FullName;
                     break;
                 default:
-                    f = t => GetPropValue(t, propName) as string; //determine whether the Title, by which groups are made, start with number, letter or symbol. On the basis of that we define the Key for each Group.
+                    f = t => GetPropValue(t, propName) as string; 
                     break;
             }          
             return f;


### PR DESCRIPTION
If a song's title only has one character, a  **ArgumentOutOfRangeException** will be thrown in StringExtensions.cs

StackTrace:

```
 System.ArgumentOutOfRangeException occurred
  HResult=0x80131502
  Message=startIndex must be less than length of string.
  Source=<Cannot evaluate the exception source>
  StackTrace:
   at System.String.Remove(Int32 startIndex)
   at BreadPlayer.Extensions.StringExtensions.StartsWithLetter(String input) in BreadPlayer\BreadPlayer.Views.UWP\Extensions\StringExtensions.cs:line 16

```

and another **ArgumentOutOfRangeException** in LibraryViewModel.cs

StackTrace:

```
System.ArgumentOutOfRangeException occurred
  HResult=0x80131502
  Message=startIndex must be less than length of string.
  Source=<Cannot evaluate the exception source>
  StackTrace:
   at System.String.Remove(Int32 startIndex)
   at BreadPlayer.ViewModels.LibraryViewModel.<>c__DisplayClass127_0.<GetSortFunction>b__0(Mediafile t) in BreadPlayer\BreadPlayer.Views.UWP\ViewModels\LibraryViewModel.cs:line 666

```